### PR TITLE
removing the sync post example

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -132,7 +132,7 @@ default_input_async: dict = {
 }
 
 # define the default request bodies
-default_request_sync: Body = Body(default=default_input_sync, example=default_input_sync, )
+default_request_sync: Body = Body(default=default_input_sync)
 default_request_async: Body = Body(default=default_input_async, example=default_input_async)
 
 # get the queue connection params


### PR DESCRIPTION
the smartapi folks said this is timing out suggested it be removed.