### PR TITLE
Added a timeout for strider.

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -28,7 +28,7 @@ with pkg_resources.resource_stream('src', 'logging.yml') as f:
 log_dir = './logs'
 
 # set the app version
-APP_VERSION = '2.0.21'
+APP_VERSION = '2.0.22'
 
 # make the directory if it does not exist
 if not os.path.exists(log_dir):

--- a/src/service_aggregator.py
+++ b/src/service_aggregator.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from fastapi import HTTPException
 from requests.models import Response
 from requests.exceptions import ConnectionError
+from asyncio.exceptions import TimeoutError
 
 logger = logging.getLogger(__name__)
 
@@ -127,8 +128,8 @@ async def post_async(host_url, query, guid, params=None):
             # declare the queue using the guid as the key
             queue = await channel.declare_queue(guid, auto_delete=True)
 
-            # wait for the response
-            async with queue.iterator() as queue_iter:
+            # wait for the response.  Timeout after 4 hours
+            async with queue.iterator(timeout=60*60*4) as queue_iter:
                 # wait the for the message
                 async for message in queue_iter:
                     async with message.process():
@@ -140,6 +141,11 @@ async def post_async(host_url, query, guid, params=None):
 
         await connection.close()
 
+    except TimeoutError as e:
+        error_string = f'{guid}: Async query to {host_url} timed out'
+        response = Response()
+        response.status_code = 598
+        return response
     except Exception as e:
         error_string = f'{guid}: Queue error exception {e} for callback {query["callback"]}'
         logger.exception(error_string, e)
@@ -150,7 +156,6 @@ async def post_async(host_url, query, guid, params=None):
 
     # return with the message
     return response
-
 
 async def post(name, url, message, guid, asyncquery=False, params=None) -> (dict, int):
     """


### PR DESCRIPTION
This adds a timeout for async calls.  The only async call right now is to strider, and the timeout is set to 4 hours.  

The point of this is that our workers block while waiting for strider.  If something goes wrong in the handoff from strider to aragorn, then the worker is effectively dead, and eventually there are no workers to process new work.  This will free up a worker that has waited for a little while.   It would be better to make the workers stateless, but this should at least alleviate the worst problems.