### PR TITLE
Cypher endpoint patch

### DIFF
--- a/src/rules/gather_robokop_results.py
+++ b/src/rules/gather_robokop_results.py
@@ -1,3 +1,5 @@
+import os
+
 import requests
 from rules import rules
 import json
@@ -15,7 +17,7 @@ def get_redis(db=1):
     return r
 
 async def get_input_ids():
-    automat_url ='https://automat.renci.org/robokopkg/cypher'
+    automat_url = os.environ.get("ROBOKOP_CYPHER_ENDPOINT", 'https://automat.renci.org/robokopkg/cypher')
     query = {"query": "MATCH (n:`biolink:DiseaseOrPhenotypicFeature`) RETURN n.id"}
     results = requests.post(automat_url,json=query).json()
     dids = [ result['row'][0] for result in results['results'][0]['data'] ]

--- a/src/service_aggregator.py
+++ b/src/service_aggregator.py
@@ -387,7 +387,7 @@ async def aragorn_lookup(input_message,params,guid,infer,answer_qnode):
     messages = await expand_query(input_message,params,guid)
     nrules_per_batch = os.environ.get("MULTISTRIDER_BATCH_SIZE", 3)
     nrules = os.environ.get("MAXIMUM_MULTISTRIDER_RULES",len(messages))
-    logger.info(f"infering<{guid}>: nrules={nrules} per_batch: {nrules_per_batch}")
+    logger.info(f"infering<{guid}>: nrules={nrules} per_batch: {nrules_per_batch}, total rules: {len(messages)}")
     result_messages = []
     num = 0
     for to_run in chunk(messages[:nrules],nrules_per_batch):

--- a/src/service_aggregator.py
+++ b/src/service_aggregator.py
@@ -387,6 +387,7 @@ async def aragorn_lookup(input_message,params,guid,infer,answer_qnode):
     messages = await expand_query(input_message,params,guid)
     nrules_per_batch = os.environ.get("MULTISTRIDER_BATCH_SIZE", 3)
     nrules = os.environ.get("MAXIMUM_MULTISTRIDER_RULES",len(messages))
+    logger.info(f"infering<{guid}>: nrules={nrules} per_batch: {nrules_per_batch}")
     result_messages = []
     num = 0
     for to_run in chunk(messages[:nrules],nrules_per_batch):

--- a/src/service_aggregator.py
+++ b/src/service_aggregator.py
@@ -385,9 +385,8 @@ async def aragorn_lookup(input_message,params,guid,infer,answer_qnode):
         return await strider(input_message,params,guid)
     #Now it's an infer query.
     messages = await expand_query(input_message,params,guid)
-    nrules_per_batch = os.environ.get("MULTISTRIDER_BATCH_SIZE", 3)
-    nrules = os.environ.get("MAXIMUM_MULTISTRIDER_RULES",len(messages))
-    logger.info(f"infering<{guid}>: nrules={nrules} per_batch: {nrules_per_batch}, total rules: {len(messages)}")
+    nrules_per_batch = int(os.environ.get("MULTISTRIDER_BATCH_SIZE", 3))
+    nrules = int(os.environ.get("MAXIMUM_MULTISTRIDER_RULES",len(messages)))
     result_messages = []
     num = 0
     for to_run in chunk(messages[:nrules],nrules_per_batch):


### PR DESCRIPTION
1. Makes robokopkg cypher endpoint configurable to avoid having to use proxy when deploying in sterling cluster
2. Env variables for `MULTISTRIDER_BATCH_SIZE` and `MAXIMUM_MULTISTRIDER_RULES` are being parsed as string causing slicing error in the for loop. Casting them to integer fixes the issue 