### PR TITLE
fixed url for robokop infer

### DIFF
--- a/src/service_aggregator.py
+++ b/src/service_aggregator.py
@@ -598,11 +598,11 @@ async def merge_results_by_node(result_message, merge_qnode):
 
 
 async def robokop_infer(input_message, guid, question_qnode, answer_qnode):
-    automat_url = os.environ.get("ROBOKOPKG_URL", "https://automat.transltr.io/robokopkg/1.3/query")
+    automat_url = os.environ.get("ROBOKOPKG_URL", "https://automat.transltr.io/robokopkg/1.3/")
     messages = await expand_query(input_message,{},guid)
     result_messages = []
     for message in messages:
-        results = requests.post(automat_url,json=message)
+        results = requests.post(f"{automat_url}query",json=message)
         if results.status_code == 200:
             message = results.json()
             if len(message['message']['results']) > 0:


### PR DESCRIPTION
There are different functions using the ROBKOPKG variable.  (lookup and infer). In the place that worked (lookup) it wasn't expecting query to be part of the environment variable and the place that didnt' it did have the query.