### PR TITLE
Fix aragorn hang

### DIFF
--- a/openapi-config.yaml
+++ b/openapi-config.yaml
@@ -11,7 +11,7 @@ servers:
 #  url: http://127.0.0.1:5000
 termsOfService: http://robokop.renci.org:7055/tos?service_long=ARAGORN&provider_long=RENCI
 title: ARAGORN
-version: 2.1.2
+version: 2.1.4
 tags:
 - name: translator
 - name: ARA

--- a/src/aragorn_app.py
+++ b/src/aragorn_app.py
@@ -117,6 +117,10 @@ async def subservice_callback(response: PDResponse,  guid: str) -> int:
             # get a channel to the queue
             channel = await connection.channel()
 
+            # only store file if there's a queue waiting for it
+            # will throw error if queue doesn't exist
+            await channel.get_queue(guid, ensure=True)
+
             # create a file path/name
             fname = ''.join(random.choices(string.ascii_lowercase, k=12))
             file_name = f'{queue_file_dir}/{guid}-{fname}-async-data.json'

--- a/src/operations.py
+++ b/src/operations.py
@@ -2,6 +2,8 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# All these functions need to be async even though they don't await
+# because all operation workflows are expected to be async
 async def sort_results_score(message,params,guid):
     logger.info(f'{guid}: sorting results.')
     results = message['message']['results']

--- a/src/server.py
+++ b/src/server.py
@@ -13,7 +13,7 @@ from src.openapi_constructor import construct_open_api_schema
 
 APP = FastAPI(title="ARAGORN/ROBOKOP")
 
-# Mount aragorn app at /
+# Mount aragorn app at /aragorn
 APP.mount('/aragorn',  ARAGORN_APP, 'ARAGORN')
 # Mount robokop app at /robokop
 APP.mount('/robokop', ROBOKOP_APP, 'ROBOKOP')

--- a/src/service_aggregator.py
+++ b/src/service_aggregator.py
@@ -1,7 +1,7 @@
 """Literature co-occurrence support."""
 import json
 import logging
-import requests
+import httpx
 import os
 import aio_pika
 from collections import defaultdict
@@ -137,12 +137,12 @@ async def entry(message, guid, coalesce_type, caller) -> (dict, int):
     return final_answer, status_code
 
 
-async def is_end_message(message):
+def is_end_message(message):
     if message.get('status_communication', {}).get('strider_multiquery_status','running') == 'complete':
         return True
     return False
 
-async def post_async(host_url, query, guid, params=None):
+async def post_with_callback(host_url, query, guid, params=None):
     """
     Post an asynchronous message.
 
@@ -185,16 +185,36 @@ async def post_async(host_url, query, guid, params=None):
     await create_queue(guid)
 
     # Send the query, using the pid for the callback
-    if params is None:
-        post_response = requests.post(host_url, json=query)
-    else:
-        post_response = requests.post(host_url, json=query, params=params)
+    try:
+        # these requests should be very quick, if the external service is responsive, they should send back a quick
+        # response and then we watch the queue. We give a short 1 min timeout.
+        async with httpx.AsyncClient(timeout=httpx.Timeout(timeout=60)) as client:
+            if params is None:
+                post_response = await client.post(
+                    host_url,
+                    json=query,
+                )
+            else:
+                post_response = await client.post(
+                    host_url,
+                    json=query,
+                    params=params,
+                )
+        # check the response status.
+        if post_response.status_code != 200:
+            # queue isn't needed for failed service call
+            logger.warn(f"Deleting unneeded queue for {guid}")
+            await delete_queue(guid)
+            # if there is an error this will return a <requests.models.Response> type
+            return post_response
+    except httpx.RequestError as e:
+        logger.error(f"Failed to contact {host_url}")
+        await delete_queue(guid)
+        # exception handled in subservice_post
+        raise
 
-    # check the response status.
-    if post_response.status_code != 200:
-        # if there is an error this will return a <requests.models.Response> type
-        return post_response
 
+    # async wait for callbacks to come on queue
     response = await assemble_callbacks(guid,num_queries)
     return response
 
@@ -283,9 +303,9 @@ async def check_for_messages(guid, pydantic_kgraph, accumulated_results, num_que
                     async with message.process():
                         num_responses += 1
                         logger.debug(f'{guid}: Strider returned {num_responses} out of {num_queries}.')
-                        jr = await process_message(message)
-                        if await is_end_message(jr):
-                            logger.debug('Received complete message from multistrider')
+                        jr = process_message(message)
+                        if is_end_message(jr):
+                            logger.debug(f'{guid}: Received complete message from multistrider')
                             complete = True
                             break
 
@@ -297,7 +317,7 @@ async def check_for_messages(guid, pydantic_kgraph, accumulated_results, num_que
                         # this is a little messy because this is trying to handle multiquery (returns an end message)
                         # and single query (no end message; single query)
                         if num_queries == 1:
-                            logger.debug('Single message returned from strider; continuing')
+                            logger.debug(f'{guid}: Single message returned from strider; continuing')
                             complete = True
                             break
 
@@ -309,8 +329,7 @@ async def check_for_messages(guid, pydantic_kgraph, accumulated_results, num_que
 # return with the message
     return response
 
-
-async def process_message(message):
+def process_message(message):
     file_name = message.body.decode()
     # open and save the file saved from the callback
     with open(file_name, 'r') as f:
@@ -355,12 +374,21 @@ async def subservice_post(name, url, message, guid, asyncquery=False, params=Non
         # launch the post depending on the query type and get the response
         if asyncquery:
             # handle the response
-            response = await post_async(url, message, guid, params)
+            response = await post_with_callback(url, message, guid, params)
         else:
-            if params is None:
-                response = requests.post(url, json=message)
-            else:
-                response = requests.post(url, json=message, params=params)
+            # async call to external services with hour timeout
+            async with httpx.AsyncClient(timeout=httpx.Timeout(timeout=60*60)) as client:
+                if params is None:
+                    response = await client.post(
+                        url,
+                        json=message,
+                    )
+                else:
+                    response = await client.post(
+                        url,
+                        json=message,
+                        params=params,
+                    )
 
 
         # save the response code
@@ -385,6 +413,10 @@ async def subservice_post(name, url, message, guid, asyncquery=False, params=Non
         status_code = 500
         logger.exception(f"{guid}: ARAGORN Exception {e} posting to {name}")
 
+    if ('message' not in ret_val):
+        # this mainly handles multistrider exceptions
+        # grab first sub-query
+        ret_val = ret_val.items()[0]
 
     #The query_graph is getting dropped under some circumstances.  This really isn't the place to fix it
     if (ret_val['message']['query_graph'] is None) and ('message' in message):
@@ -445,7 +477,7 @@ async def aragorn_lookup(input_message,params,guid,infer,answer_qnode):
     if not infer:
         return await strider(input_message,params,guid)
     #Now it's an infer query.
-    messages = await expand_query(input_message,params,guid)
+    messages = expand_query(input_message,params,guid)
     nrules_per_batch = int(os.environ.get("MULTISTRIDER_BATCH_SIZE", 100))
     #nrules = int(os.environ.get("MAXIMUM_MULTISTRIDER_RULES",len(messages)))
     nrules = int(os.environ.get("MAXIMUM_MULTISTRIDER_RULES",75))
@@ -472,13 +504,13 @@ async def aragorn_lookup(input_message,params,guid,infer,answer_qnode):
     result['message']['query_graph'] = deepcopy(input_message['message']['query_graph'])
     for rm in result_messages[1:]:
         result['message']['results'].extend( rm['message']['results'])
-    mergedresults = await merge_results_by_node(result,answer_qnode)
+    mergedresults = merge_results_by_node(result,answer_qnode)
     logger.info(f'{guid}: results merged')
     return mergedresults, sc
 
-async def merge_results_by_node_op(message,params,guid) -> (dict,int):
+def merge_results_by_node_op(message,params,guid) -> (dict,int):
     qn = params['merge_qnode']
-    merged_results = await merge_results_by_node(message, qn)
+    merged_results = merge_results_by_node(message, qn)
     return merged_results,200
 
 async def strider(message,params,guid) -> (dict, int):
@@ -506,7 +538,11 @@ async def normalize_qgraph_ids(m):
         if 'ids' in qnode:
             qnode_ids.update(qnode['ids'])
     nnp = { "curies": list(qnode_ids), "conflate": True }
-    nnresult = requests.post(url,json=nnp)
+    async with httpx.AsyncClient(timeout=httpx.Timeout(timeout=120)) as client:
+        nnresult = await client.post(
+            url,
+            json=nnp,
+        )
     if nnresult.status_code == 200:
         for qid, qnode in qnodes.items():
             if 'ids' in qnode:
@@ -529,7 +565,7 @@ async def robokop_lookup(message,params,guid,infer,question_qnode,answer_qnode) 
 
 
 #TODO this is a temp implementation that assumes we will have (something treats identifier) as the query.
-async def expand_query(input_message,params,guid):
+def expand_query(input_message,params,guid):
     #What are the relevant qnodes and ids from the input message?
     for edge_id, edge in input_message['message']['query_graph']['edges'].items():
         input_q_chemical_node = edge['subject']
@@ -551,7 +587,7 @@ async def multi_strider(messages,params,guid):
 
     return response, status_code
 
-async def merge_answer(results,qnode_ids):
+def merge_answer(results,qnode_ids):
     #We are going rename most of the node and edge bindings.  But, we want to preserve bindings to things in the
     # original query.  For the current creative one-hop, that is just nodes b/c we are replacing the one edge.
     #The original qnode bindings are the same in all results by construction
@@ -574,7 +610,7 @@ async def merge_answer(results,qnode_ids):
     return mergedresult
 
 #TODO move into operations? Make a translator op out of this
-async def merge_results_by_node(result_message, merge_qnode):
+def merge_results_by_node(result_message, merge_qnode):
     """This assumes a single result message, with a single merged KG.  The goal is to take all results that share a
     binding for merge_qnode and combine them into a single result.
     Assumes that the results are not scored."""
@@ -591,7 +627,7 @@ async def merge_results_by_node(result_message, merge_qnode):
     #TODO : I'm sure there's a better way to handle this with asyncio
     new_results = []
     for r in grouped_results:
-        x = await merge_answer(grouped_results[r],original_qnodes)
+        x = merge_answer(grouped_results[r],original_qnodes)
         new_results.append(x)
     result_message['message']['results'] = new_results
     return result_message
@@ -599,10 +635,15 @@ async def merge_results_by_node(result_message, merge_qnode):
 
 async def robokop_infer(input_message, guid, question_qnode, answer_qnode):
     automat_url = os.environ.get("ROBOKOPKG_URL", "https://automat.transltr.io/robokopkg/1.3/")
-    messages = await expand_query(input_message,{},guid)
+    messages = expand_query(input_message,{},guid)
     result_messages = []
     for message in messages:
-        results = requests.post(f"{automat_url}query",json=message)
+        # async timeout in 1 hour
+        async with httpx.AsyncClient(timeout=httpx.Timeout(timeout=60*60)) as client:
+            results = await client.post(
+                f"{automat_url}query",
+                json=message,
+            )
         if results.status_code == 200:
             message = results.json()
             if len(message['message']['results']) > 0:
@@ -617,7 +658,7 @@ async def robokop_infer(input_message, guid, question_qnode, answer_qnode):
         result['message']['knowledge_graph'] = pydantic_kgraph.dict()
         for rm in result_messages[1:]:
             result['message']['results'].extend(rm['message']['results'])
-        mergedresults = await merge_results_by_node(result, answer_qnode)
+        mergedresults = merge_results_by_node(result, answer_qnode)
     else:
         mergedresults = {'message':{'knowledge_graph':{'nodes':{},'edges':{}}, 'results':[]}}
     #The merged results will have some expanded query, we want the original query.

--- a/src/service_aggregator.py
+++ b/src/service_aggregator.py
@@ -104,17 +104,21 @@ async def entry(message, guid, coalesce_type, caller) -> (dict, int):
         del message['workflow']
     else:
         if infer:
-            workflow_def = [{'id': 'lookup'},
-                            {'id': 'overlay_connect_knodes'},
-                            {'id': 'score'},
-                            {'id': 'filter_message_top_n', 'parameters': {'max_results': 500}}]
+            workflow_def = [
+                {'id': 'lookup'},
+                {'id': 'overlay_connect_knodes'},
+                {'id': 'score'},
+                {'id': 'filter_message_top_n', 'parameters': {'max_results': 500}}
+            ]
         else:
             #TODO: if this is robokop, need to normalize.
-            workflow_def = [{'id': 'lookup'},
-                            {'id': 'enrich_results', 'parameters': {'max_input_size': 5000}},
-                            {'id': 'overlay_connect_knodes'},
-                            {'id': 'score'},
-                            {'id': 'filter_message_top_n', 'parameters': {'max_results': 5000}}]
+            workflow_def = [
+                {'id': 'lookup'},
+                {'id': 'enrich_results', 'parameters': {'max_input_size': 5000}},
+                {'id': 'overlay_connect_knodes'},
+                {'id': 'score'},
+                {'id': 'filter_message_top_n', 'parameters': {'max_results': 5000}}
+            ]
 
     # convert the workflow def into function calls.
     # Raise a 422 if we find one we don't actually know how to do.
@@ -238,7 +242,7 @@ async def assemble_callbacks(guid,num_queries):
     while not done:
         num_new_responses, done = await check_for_messages(guid, pydantic_kgraph, accumulated_results, num_queries)
         num_responses += num_new_responses
-        time_spent = datetime.now() - start
+        time_spent = dt.now() - start
         if time_spent > OVERALL_TIMEOUT:
             logger.info(f'{guid}: Timing out receiving callbacks')
             done = True
@@ -326,8 +330,6 @@ async def check_for_messages(guid, pydantic_kgraph, accumulated_results, num_que
 
     return num_responses, complete
 
-# return with the message
-    return response
 
 def process_message(message):
     file_name = message.body.decode()

--- a/tests/test_result_merge.py
+++ b/tests/test_result_merge.py
@@ -1,8 +1,7 @@
 import pytest
 from src.service_aggregator import merge_results_by_node
 
-@pytest.mark.asyncio
-async def test_simple_merge():
+def test_simple_merge():
     m = {'message':
     {"query_graph": {"nodes": { "drug":{"categories":["biolink:ChemicalEntity"]},
                                 "disease": {"ids": ["MONDO:1234"]}},
@@ -15,7 +14,7 @@ async def test_simple_merge():
           "edge_bindings": {"_1": [{"id": "e2"}]}},
      ]
      }}
-    m = await merge_results_by_node(m,'drug')
+    m = merge_results_by_node(m,'drug')
     results = m['message']['results']
     assert len(results) == 1
     assert len(results[0]['node_bindings']) == 2


### PR DESCRIPTION
Most external api requests were still synchronous (blocking) with no timeouts, so if any services (Strider) were unresponsive, Aragorn would wait indefinitely and hang when it received enough requests to occupy all its workers.

This PR converts all `requests` with `httpx` asynchronous requests with reasonable timeouts. Now external calls should not be blocking and will raise an exception when the timeout limit is reached.

I also put a check in the aragorn `/callback` endpoint to make sure there is an active queue for the response before saving a new file. I don't think this has been a problem, but this will keep disk usage from ballooning if anything does go sideways in the queues.