### PR TITLE
fix robokop bug

### DIFF
--- a/openapi-config.yaml
+++ b/openapi-config.yaml
@@ -11,7 +11,7 @@ servers:
 #  url: http://127.0.0.1:5000
 termsOfService: http://robokop.renci.org:7055/tos?service_long=ARAGORN&provider_long=RENCI
 title: ARAGORN
-version: 2.1.5
+version: 2.1.6
 tags:
 - name: translator
 - name: ARA


### PR DESCRIPTION
When a qgraph comes in without ids, pydantic(?) is turning it into "ids":None, causing the update line to throw an exception.