### PR TITLE
Otel implementation for aragorn

### DIFF
--- a/openapi-config.yaml
+++ b/openapi-config.yaml
@@ -11,7 +11,7 @@ servers:
 #  url: http://127.0.0.1:5000
 termsOfService: http://robokop.renci.org:7055/tos?service_long=ARAGORN&provider_long=RENCI
 title: ARAGORN
-version: 2.3.10
+version: 2.3.11
 tags:
 - name: translator
 - name: ARA

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,7 @@ redis~=3.5.3
 requests==2.28.1
 uvicorn==0.17.6
 uvloop==0.17.0
+opentelemetry-sdk==1.16.0
+opentelemetry-instrumentation-fastapi==0.37b0
+opentelemetry-exporter-jaeger==1.16.0
+opentelemetry-instrumentation-httpx==0.37b0

--- a/src/aragorn_app.py
+++ b/src/aragorn_app.py
@@ -16,9 +16,15 @@ from src.openapi_constructor import construct_open_api_schema
 from src.common import async_query, sync_query
 from src.default_queries import default_input_sync, default_input_async
 from src.util import get_channel_pool
+from src.otel_config import configure_otel
 
 # declare the FastAPI details
-ARAGORN_APP = FastAPI(title="ARAGORN")
+title = "ARAGORN"
+ARAGORN_APP = FastAPI(title=title)
+
+# configures open telemetry iff enabled.
+service_name = os.environ.get('OTEL_SERVICE_NAME', 'ARAGORN') + '-' + title
+configure_otel(service_name=service_name, APP=ARAGORN_APP)
 
 # Set up default logger.
 with pkg_resources.resource_stream("src", "logging.yml") as f:

--- a/src/otel_config.py
+++ b/src/otel_config.py
@@ -3,7 +3,7 @@ import logging, warnings, os
 
 def configure_otel(service_name, APP):
     # open telemetry
-    if os.environ.get('JAEGER_ENALBED') == "True":
+    if os.environ.get('JAEGER_ENABLED') == "True":
         logging.info("starting up jaeger telemetry")
 
         from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor

--- a/src/otel_config.py
+++ b/src/otel_config.py
@@ -1,0 +1,38 @@
+import logging, warnings, os
+
+
+def configure_otel(service_name, APP):
+    # open telemetry
+    if os.environ.get('JAEGER_ENALBED') == "True":
+        logging.info("starting up jaeger telemetry")
+
+        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+        from opentelemetry import trace
+        from opentelemetry.exporter.jaeger.thrift import JaegerExporter
+        from opentelemetry.sdk.resources import SERVICE_NAME as telemetery_service_name_key, Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+        from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+
+        # httpx connections need to be open a little longer by the otel decorators
+        # but some libs display warnings of resource being unclosed.
+        # these supresses such warnings.
+        logging.captureWarnings(capture=True)
+        warnings.filterwarnings("ignore",category=ResourceWarning)
+        jaeger_host = os.environ.get('JAEGER_HOST', 'jaeger-otel-agent')
+        jaeger_port = int(os.environ.get('JAEGER_PORT', '6831'))
+        trace.set_tracer_provider(
+            TracerProvider(
+                resource=Resource.create({telemetery_service_name_key: service_name})
+            )
+        )
+        jaeger_exporter = JaegerExporter(
+            agent_host_name=jaeger_host,
+            agent_port=jaeger_port,
+        )
+        trace.get_tracer_provider().add_span_processor(
+            BatchSpanProcessor(jaeger_exporter)
+        )
+        tracer = trace.get_tracer(__name__)
+        FastAPIInstrumentor.instrument_app(APP, tracer_provider=trace, excluded_urls="docs,openapi.json")
+        HTTPXClientInstrumentor().instrument()

--- a/src/robokop_app.py
+++ b/src/robokop_app.py
@@ -13,10 +13,14 @@ from fastapi import Body, FastAPI, BackgroundTasks
 from src.openapi_constructor import construct_open_api_schema
 from src.common import sync_query, async_query
 from src.default_queries import default_input_sync, default_input_async
+# import open telemetery configuration
+from otel_config import configure_otel
 
 # declare the FastAPI details
-ROBOKOP_APP = FastAPI(title="ROBOKOP")
-
+title = "ROBOKOP"
+ROBOKOP_APP = FastAPI(title=title)
+service_name = os.environ.get('OTEL_SERVICE_NAME', 'ARAGORN') + '-' + title
+configure_otel(service_name=service_name, APP=ROBOKOP_APP)
 # Set up default logger.
 with pkg_resources.resource_stream("src", "logging.yml") as f:
     config = yaml.safe_load(f.read())

--- a/src/robokop_app.py
+++ b/src/robokop_app.py
@@ -14,7 +14,7 @@ from src.openapi_constructor import construct_open_api_schema
 from src.common import sync_query, async_query
 from src.default_queries import default_input_sync, default_input_async
 # import open telemetery configuration
-from otel_config import configure_otel
+from src.otel_config import configure_otel
 
 # declare the FastAPI details
 title = "ROBOKOP"

--- a/src/server.py
+++ b/src/server.py
@@ -34,39 +34,3 @@ APP.add_middleware(
     allow_headers=["*"],
 )
 
-# open telemetry
-if os.environ.get('JAEGER_ENALBED') == "True":
-    logging.info("starting up jaeger telemetry")
-
-    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
-    from opentelemetry import trace
-    from opentelemetry.exporter.jaeger.thrift import JaegerExporter
-    from opentelemetry.sdk.resources import SERVICE_NAME as telemetery_service_name_key, Resource
-    from opentelemetry.sdk.trace import TracerProvider
-    from opentelemetry.sdk.trace.export import BatchSpanProcessor
-    from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
-
-    # httpx connections need to be open a little longer by the otel decorators
-    # but some libs display warnings of resource being unclosed.
-    # these supresses such warnings.
-    logging.captureWarnings(capture=True)
-    warnings.filterwarnings("ignore",category=ResourceWarning)
-    service_name = os.environ.get('OTEL_SERVICE_NAME', 'ARAGORN')
-    jaeger_host = os.environ.get('JAEGER_HOST', 'jaeger-otel-agent')
-    jaeger_port = int(os.environ.get('JAEGER_PORT', '6831'))
-    trace.set_tracer_provider(
-        TracerProvider(
-            resource=Resource.create({telemetery_service_name_key: service_name})
-        )
-    )
-    jaeger_exporter = JaegerExporter(
-        agent_host_name=jaeger_host,
-        agent_port=jaeger_port,
-    )
-    trace.get_tracer_provider().add_span_processor(
-        BatchSpanProcessor(jaeger_exporter)
-    )
-    tracer = trace.get_tracer(__name__)
-    FastAPIInstrumentor.instrument_app(APP, tracer_provider=trace, excluded_urls="docs,openapi.json")
-    HTTPXClientInstrumentor().instrument()
-

--- a/src/server.py
+++ b/src/server.py
@@ -51,7 +51,7 @@ if os.environ.get('JAEGER_ENALBED') == "True":
     # these supresses such warnings.
     logging.captureWarnings(capture=True)
     warnings.filterwarnings("ignore",category=ResourceWarning)
-    service_name = os.environ.get('OTEL_SERVICE_NAME', 'STRIDER')
+    service_name = os.environ.get('OTEL_SERVICE_NAME', 'ARAGORN')
     jaeger_host = os.environ.get('JAEGER_HOST', 'jaeger-otel-agent')
     jaeger_port = int(os.environ.get('JAEGER_PORT', '6831'))
     trace.set_tracer_provider(

--- a/src/server.py
+++ b/src/server.py
@@ -1,4 +1,6 @@
 """wrapper for aragorn and robokop."""
+import os
+import logging, warnings
 
 from fastapi import Body, FastAPI, BackgroundTasks
 from fastapi.middleware.cors import CORSMiddleware
@@ -31,4 +33,40 @@ APP.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# open telemetry
+if os.environ.get('JAEGER_ENALBED') == "True":
+    logging.info("starting up jaeger telemetry")
+
+    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+    from opentelemetry import trace
+    from opentelemetry.exporter.jaeger.thrift import JaegerExporter
+    from opentelemetry.sdk.resources import SERVICE_NAME as telemetery_service_name_key, Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+
+    # httpx connections need to be open a little longer by the otel decorators
+    # but some libs display warnings of resource being unclosed.
+    # these supresses such warnings.
+    logging.captureWarnings(capture=True)
+    warnings.filterwarnings("ignore",category=ResourceWarning)
+    service_name = os.environ.get('OTEL_SERVICE_NAME', 'STRIDER')
+    jaeger_host = os.environ.get('JAEGER_HOST', 'jaeger-otel-agent')
+    jaeger_port = int(os.environ.get('JAEGER_PORT', '6831'))
+    trace.set_tracer_provider(
+        TracerProvider(
+            resource=Resource.create({telemetery_service_name_key: service_name})
+        )
+    )
+    jaeger_exporter = JaegerExporter(
+        agent_host_name=jaeger_host,
+        agent_port=jaeger_port,
+    )
+    trace.get_tracer_provider().add_span_processor(
+        BatchSpanProcessor(jaeger_exporter)
+    )
+    tracer = trace.get_tracer(__name__)
+    FastAPIInstrumentor.instrument_app(APP, tracer_provider=trace, excluded_urls="docs,openapi.json")
+    HTTPXClientInstrumentor().instrument()
 


### PR DESCRIPTION
- Adds telemetry for Aragorn and Robokop servers , 
- Example runs 
 - Aragorn - https://translator-otel.apps.renci.org/trace/1fa6cf71b13f8cde3f481bcb299d94fa
 - Robokop - https://translator-otel.apps.renci.org/trace/491ab49249d2429d0ba1509a6bef8eb3