### PR TITLE
TRAPI 1.4 request/response

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ pytest==7.1.2
 pytest-asyncio==0.15.1
 pytest-dotenv==0.5.2
 pyyaml==6.0
-reasoner-pydantic==3.0.0
+reasoner-pydantic@git+https://github.com/TranslatorSRI/reasoner-pydantic@v4.0.1
 redis~=3.5.3
 requests==2.28.1
 uvicorn==0.17.6

--- a/src/service_aggregator.py
+++ b/src/service_aggregator.py
@@ -18,6 +18,7 @@ from requests.exceptions import ConnectionError
 from asyncio.exceptions import TimeoutError
 from reasoner_pydantic import Query, KnowledgeGraph
 from reasoner_pydantic import Response as PDResponse
+import uuid
 
 #from src.rules.rules import rules as AMIE_EXPANSIONS
 
@@ -678,13 +679,71 @@ async def multi_strider(messages, params, guid):
     return response, status_code
 
 
-def merge_answer(results, qnode_ids):
-    # We are going rename most of the node and edge bindings.  But, we want to preserve bindings to things in the
-    # original query.  For the current creative one-hop, that is just nodes b/c we are replacing the one edge.
-    # The original qnode bindings are not necessarily the same because of the dumb way that we are handling
-    # subclass entailment.  If one of the merged answers involved a subclass, then the qnode binding will be
-    # to the subclass. So we loop over all the results and find all the different qnode bindings by serializing.
-    mergedresult = {"node_bindings": {}, "edge_bindings": {}}
+def create_aux_graph(analysis):
+    """Given an analysis, create an auxiliary graph.
+    Look through the analysis edge bindings, get all the knowledge edges, and put them in an aux graph.
+    Give it a random uuid as an id."""
+    aux_graph_id = str(uuid.uuid4())
+    aux_graph = { "edges": [] }
+    for edge_id, edgelist in analysis["edge_bindings"].items():
+        for edge in edgelist:
+            aux_graph["edges"].append(edge["id"])
+    return aux_graph_id, aux_graph
+
+
+def add_knowledge_edge(result_message, aux_graph_ids, answer):
+    """Create a new knowledge edge in the result message, with the aux graph ids as support."""
+    # Find the subject, object, and predicate of the original query
+    query_graph = result_message["message"]["query_graph"]
+    #get the first key and value from the edges
+    qedge_id, qedge = next(iter(query_graph["edges"].items()))
+    #For the nodes, if there is an id, then use it in the knowledge edge. If there is not, then use the answer
+    qnode_subject_id = qedge["subject"]
+    qnode_object_id = qedge["object"]
+    if "ids" in query_graph["nodes"][qnode_subject_id] and query_graph["nodes"][qnode_subject_id]["ids"] is not None:
+        qnode_subject = query_graph["nodes"][qnode_subject_id]["ids"][0]
+        qnode_object = answer
+    else:
+        qnode_subject = answer
+        qnode_object = query_graph["nodes"][qnode_object_id]["ids"][0]
+    predicate = qedge["predicates"][0]
+    # Create a new knowledge edge
+    new_edge_id = str(uuid.uuid4())
+    new_edge = {
+        "subject": qnode_subject,
+        "object": qnode_object,
+        "predicate": predicate,
+        "attributes": [
+            {
+                "attribute_type_id": "support graph",
+                "value": aux_graph_ids
+            }
+        ],
+        "sources": [{"resource_id":"infores:aragorn", "resource_role":"biolink:primary_knowledge_source"}]
+    }
+    result_message["message"]["knowledge_graph"]["edges"][new_edge_id] = new_edge
+    return new_edge_id
+
+
+def merge_answer(result_message, answer, results, qnode_ids):
+    """Given a set of results and the node identifiers of the original qgraph,
+    create a single message.
+    The original qgraph is a creative mode query, which has been expanded into a set of
+    rules and run as straight queries using either strider or robokopkg.
+    Each result coming in is now structured like this:
+    result
+        node_bindings: Binding to the rule qnodes. includes bindings to original qnode ids
+        analysis:
+            edge_bindings: Binding to the rule edges.
+    To merge the answer, we need to
+    1) create node bindings for the original creative qnodes
+    2) convert the analysis of each input result into an auxiliary graph
+    3) Create a knowledge edge corresponding to the original creative query edge
+    4) add the aux graphs as support for this knowledge edge
+    5) create an analysis with an edge binding from the original creative query edge to the new knowledge edge
+    """
+    # 1. Create node bindings for the original creative qnodes
+    mergedresult = {"node_bindings": {}, "analyses": []}
     serkeys = defaultdict(set)
     for q in qnode_ids:
         mergedresult["node_bindings"][q] = []
@@ -695,20 +754,26 @@ def merge_answer(results, qnode_ids):
                     mergedresult["node_bindings"][q].append(nb)
                     serkeys[q].add(serialized_binding)
 
-    for bindingtype in ["node", "edge"]:
-        bound_things = set()
-        for result in results:
-            # the gross part here is dealing with the lists in the values of the bindings.
-            for key, binding in result[f"{bindingtype}_bindings"].items():
-                if key in qnode_ids:
-                    continue
-                bound = frozenset([x["id"] for x in binding])
-                if bound not in bound_things:
-                    # found a binding to add
-                    n = f"_dummy_{bindingtype}_{len(bound_things)}"
-                    mergedresult[f"{bindingtype}_bindings"][n] = binding
-                    bound_things.add(bound)
-    return mergedresult
+    # 2. convert the analysis of each input result into an auxiliary graph
+    aux_graph_ids = []
+    for result in results:
+        for analysis in result["analyses"]:
+            aux_graph_id, aux_graph = create_aux_graph(analysis)
+            result_message["message"]["auxiliary_graphs"][aux_graph_id] = aux_graph
+            aux_graph_ids.append(aux_graph_id)
+
+    # 3. Create a knowledge edge corresponding to the original creative query edge
+    # 4. and add the aux graphs as support for this knowledge edge
+    knowledge_edge_id = add_knowledge_edge(result_message, aux_graph_ids, answer)
+
+    # 5. create an analysis with an edge binding from the original creative query edge to the new knowledge edge
+    qedge_id = list(result_message["message"]["query_graph"]["edges"].keys())[0]
+    analysis = {"edge_bindings":
+                    {qedge_id: [knowledge_edge_id]}
+                }
+    mergedresult["analyses"].append(analysis)
+
+    result_message["message"]["results"].append(mergedresult)
 
 
 # TODO move into operations? Make a translator op out of this
@@ -718,8 +783,18 @@ def merge_results_by_node(result_message, merge_qnode):
     Assumes that the results are not scored."""
     # This is relatively straightforward: group all the results by the merge_qnode
     # for each one, the only complication is in the keys for the "dummy" bindings.
-    original_results = result_message["message"].get("results",[])
+    grouped_results = group_results_by_qnode(merge_qnode, result_message)
     original_qnodes = result_message["message"]["query_graph"]["nodes"].keys()
+    # TODO : I'm sure there's a better way to handle this with asyncio
+    new_results = []
+    for r in grouped_results:
+        merge_answer(result_message, r, grouped_results[r], original_qnodes)
+    return result_message
+
+
+def group_results_by_qnode(merge_qnode, result_message):
+    """"""
+    original_results = result_message["message"].get("results", [])
     # group results
     grouped_results = defaultdict(list)
     # Group results by the merge_qnode
@@ -727,13 +802,8 @@ def merge_results_by_node(result_message, merge_qnode):
         answer = result["node_bindings"][merge_qnode]
         bound = frozenset([x["id"] for x in answer])
         grouped_results[bound].append(result)
-    # TODO : I'm sure there's a better way to handle this with asyncio
-    new_results = []
-    for r in grouped_results:
-        x = merge_answer(grouped_results[r], original_qnodes)
-        new_results.append(x)
-    result_message["message"]["results"] = new_results
-    return result_message
+    return grouped_results
+
 
 async def make_one_request(client, automat_url, message, sem):
     async with sem:

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,0 +1,89 @@
+import pytest
+from src.service_aggregator import merge_answer, create_aux_graph, add_knowledge_edge
+from reasoner_pydantic.results import Analysis, EdgeBinding, Result, NodeBinding
+from reasoner_pydantic.auxgraphs import AuxiliaryGraph
+from reasoner_pydantic.message import Message, Response
+from reasoner_pydantic.qgraph import QueryGraph
+
+def create_result_graph():
+    """Create a "treats" result graph with a query graph."""
+    query_graph = {"nodes": {"input": {"ids": ["MONDO:1234"]}, "output": {"categories": ["biolink:ChemicalEntity"]}},
+        "edges": {"e": {"subject": "output", "object": "input", "predicates": ["biolink:treats"]}}}
+    result_message = {"query_graph": query_graph, "knowledge_graph": {"nodes":{}, "edges":{}}, "auxiliary_graphs": set(), "results": []}
+    pydantic_message = Response(**{"message":result_message})
+    return pydantic_message
+
+def create_result(node_bindings: dict[str,str], edge_bindings: dict[str,str]) -> Result:
+    """Pretend that we've had a creative mode query, and then broken it into rules.  THose rules run as individual
+    queries in strider or robokop, and this is a result."""
+    analysis = Analysis(edge_bindings = {k:[EdgeBinding(id=v)] for k,v in edge_bindings.items()},resource_id="infores:KP")
+    result = Result(node_bindings = {k:[NodeBinding(id=v)] for k,v in node_bindings.items()}, analyses = set([analysis]))
+    return result
+
+def test_merge_answer():
+    """Test that merge_answer() puts all the aux graphs in the right places."""
+    pydantic_result = create_result_graph()
+    result_message = pydantic_result.to_dict()
+    answer = "PUBCHEM.COMPOUND:789"
+    qnode_ids = ["input", "output"]
+    result1 = create_result({"input":"MONDO:1234", "output":answer, "node2": "curie:3"}, {"g":"KEDGE:1", "f":"KEDGE:2"}).to_dict()
+    result2 = create_result({"input":"MONDO:1234", "output":answer, "nodeX": "curie:8"}, {"q":"KEDGE:4", "z":"KEDGE:8"}).to_dict()
+    results = [result1, result2]
+    merge_answer(result_message,answer,results,qnode_ids)
+    assert len(result_message["message"]["results"]) == 1
+    assert len(result_message["message"]["results"][0]["node_bindings"]) == 2
+    assert len(result_message["message"]["results"][0]["analyses"]) == 1
+    assert len(result_message["message"]["results"][0]["analyses"][0]["edge_bindings"]) == 1
+    # e is the name of the query edge defined in create_result_graph()
+    assert "e" in result_message["message"]["results"][0]["analyses"][0]["edge_bindings"]
+    kedge_id = result_message["message"]["results"][0]["analyses"][0]["edge_bindings"]["e"][0]
+    kedge = result_message["message"]["knowledge_graph"]["edges"][kedge_id]
+    assert kedge["subject"] == "PUBCHEM.COMPOUND:789"
+    assert kedge["object"] == "MONDO:1234"
+    assert kedge["predicate"] == "biolink:treats"
+    found = False
+    for attribute in kedge["attributes"]:
+        if attribute["attribute_type_id"] == "support graph":
+            aux_graphs = attribute["value"]
+            found = True
+    assert found
+    assert len(aux_graphs) == 2
+    edges = frozenset([ frozenset( result_message["message"]["auxiliary_graphs"][aux_graph_id]["edges"] ) for aux_graph_id in aux_graphs ])
+    assert edges == frozenset([frozenset(["KEDGE:1", "KEDGE:2"]), frozenset(["KEDGE:4", "KEDGE:8"])])
+
+
+
+def test_create_aux_graph():
+    """Given an analysis object with multiple edge bindings, test that create_aux_graph() returns a valid aux graph."""
+    eb1 = EdgeBinding(id = 'eb1')
+    eb2 = EdgeBinding(id = 'eb2')
+    analysis = Analysis(resource_id = "example.com", edge_bindings = {"qedge1":[eb1], "qedge2":[eb2]})
+    agid, aux_graph = create_aux_graph(analysis.to_dict())
+    assert len(agid) == 36
+    assert aux_graph["edges"] == ["eb1", "eb2"]
+    #Make sure that we can parse the aux graph
+    axg = AuxiliaryGraph.parse_obj(aux_graph)
+
+def test_add_knowledge_edge():
+    """Test that add_knowledge_edge() runs without errors."""
+    #First make a pydantic query so that we're sure it's valid
+    pydantic_message=create_result_graph()
+    #Convert it into a dict (as it will be in the real code) and add an edge
+    result_message = pydantic_message.to_dict()
+    aux_graph_ids = ["ag1", "ag2"]
+    answer = "PUBCHEM.COMPOUND:789"
+    add_knowledge_edge(result_message, aux_graph_ids, answer)
+    #Make sure that the edge was added, that its properties are correct
+    assert len(result_message["message"]["knowledge_graph"]["edges"]) == 1
+    for edge_id, edge in result_message["message"]["knowledge_graph"]["edges"].items():
+        assert edge["subject"] == "PUBCHEM.COMPOUND:789"
+        assert edge["object"] == "MONDO:1234"
+        assert edge["predicate"] == "biolink:treats"
+        assert edge["attributes"] == [
+            {
+                "attribute_type_id": "support graph",
+                "value": aux_graph_ids
+            }
+        ]
+    #Does it validate?
+    check_message = Response.parse_obj(result_message)


### PR DESCRIPTION
Implements the TRAPI 1.4 message structure.

For lookup calls, ARAGORN doesn't really care, it's just a matter of updating the reasoner-pydantic.

For inferred calls, though, the answer merges need to pay attention to the details.  This pulls lookup answers from strider/plater, and then re-interprets these answers as auxiallary graphs supporting the original query graph.