### PR TITLE
Fixed Return Types

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ pytest==7.1.2
 pytest-asyncio==0.15.1
 pytest-dotenv==0.5.2
 pyyaml==6.0
-reasoner-pydantic==4.0.3
+reasoner-pydantic==4.0.5
 redis~=3.5.3
 requests==2.28.1
 uvicorn==0.17.6

--- a/src/aragorn_app.py
+++ b/src/aragorn_app.py
@@ -9,7 +9,7 @@ import string
 
 # from pamqp import specification as spec
 from enum import Enum
-from reasoner_pydantic import Query as PDQuery, AsyncQuery as PDAsyncQuery, Response as PDResponse
+from reasoner_pydantic import Query as PDQuery, AsyncQuery as PDAsyncQuery, Response as PDResponse, AsyncQueryResponse, AsyncQueryStatusResponse
 from pydantic import BaseModel
 from fastapi import Body, FastAPI, BackgroundTasks
 from src.openapi_constructor import construct_open_api_schema
@@ -75,13 +75,8 @@ default_request_sync: Body = Body(default=default_input_sync)
 default_request_async: Body = Body(default=default_input_async, example=default_input_async)
 
 
-# Create a async class
-class AsyncReturn(BaseModel):
-    description: str
-
-
 # async entry point
-@ARAGORN_APP.post("/asyncquery", tags=["ARAGORN"], response_model=AsyncReturn)
+@ARAGORN_APP.post("/asyncquery", tags=["ARAGORN"], response_model=AsyncQueryResponse)
 async def async_query_handler(
     background_tasks: BackgroundTasks, request: PDAsyncQuery = default_request_async, answer_coalesce_type: MethodName = MethodName.all
 ):
@@ -176,7 +171,7 @@ async def receive_aragorn_async_response(response: PDResponse) -> int:
     # return the response code
     return 200
 
-@ARAGORN_APP.get("/asyncquery_status/{job_id}", tags=["ARAGORN"], status_code=200)
+@ARAGORN_APP.get("/asyncquery_status/{job_id}", response_model=AsyncQueryStatusResponse, tags=["ARAGORN"], status_code=200)
 async def status_query_handler(job_id: str):
     """Checks the status of an asynchronous query operation."""
     return await status_query(job_id)

--- a/src/robokop_app.py
+++ b/src/robokop_app.py
@@ -5,7 +5,7 @@ import pkg_resources
 import yaml
 
 from enum import Enum
-from reasoner_pydantic import Query as PDQuery, AsyncQuery as PDAsyncQuery, Response as PDResponse
+from reasoner_pydantic import Query as PDQuery, AsyncQuery as PDAsyncQuery, Response as PDResponse, AsyncQueryStatusResponse, AsyncQueryResponse
 from pydantic import BaseModel
 
 from fastapi import Body, FastAPI, BackgroundTasks
@@ -64,13 +64,8 @@ default_request_sync: Body = Body(default=default_input_sync)
 default_request_async: Body = Body(default=default_input_async, example=default_input_async)
 
 
-# Create a async class
-class AsyncReturn(BaseModel):
-    description: str
-
-
 # async entry point
-@ROBOKOP_APP.post("/asyncquery", tags=["ROBOKOP"], response_model=AsyncReturn)
+@ROBOKOP_APP.post("/asyncquery", tags=["ROBOKOP"], response_model=AsyncQueryResponse)
 async def async_query_handler(
     background_tasks: BackgroundTasks, request: PDAsyncQuery = default_request_async, answer_coalesce_type: MethodName = MethodName.all
 ):
@@ -95,7 +90,7 @@ async def sync_query_handler(request: PDQuery = default_request_sync, answer_coa
 
     return await sync_query(request, answer_coalesce_type, logger, "ROBOKOP")
 
-@ROBOKOP_APP.get("/asyncquery_status", tags=["ROBOKOP"], status_code=200)
+@ROBOKOP_APP.get("/asyncquery_status", tags=["ROBOKOP"], response_model=AsyncQueryStatusResponse, status_code=200)
 async def status_query_handler(job_id: str):
     """Checks the status of an asynchronous query operation."""
     return await status_query(job_id)

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -27,6 +27,7 @@ def test_add_items():
     assert status_response["description"] == "The job has completed successfully."
     assert len(status_response["logs"]) == 2
     assert status_response["logs"][0]["message"] == "Starting job"
+    assert status_response["logs"][0]["level"] == "INFO"
     assert status_response["logs"][1]["message"] == "Complete"
 
 def test_running():


### PR DESCRIPTION
Historically, reasoner_pydantic did not differentiate between different return types (sync, async, status), and because of that, aragorn wasn't really compliant.

Now that has been added to reasoner_pydantic by @uhbrar , and so this incorporates those types.   It also fixes some errors in generating the log elements of the status query.