### PR TITLE
removed filter_message_top_n from openapi

### DIFF
--- a/openapi-config.yaml
+++ b/openapi-config.yaml
@@ -11,7 +11,7 @@ servers:
 #  url: http://127.0.0.1:5000
 termsOfService: http://robokop.renci.org:7055/tos?service_long=ARAGORN&provider_long=RENCI
 title: ARAGORN
-version: 2.4.4
+version: 2.4.5
 tags:
 - name: translator
 - name: ARA
@@ -32,4 +32,3 @@ x-trapi:
   - sort_results_score
   - filter_results_top_n
   - filter_kgraph_orphans
-  - filter_message_top_n


### PR DESCRIPTION
I think this should smartapi validate now.