### PR TITLE
added results cache

### DIFF
--- a/openapi-config.yaml
+++ b/openapi-config.yaml
@@ -11,7 +11,7 @@ servers:
 #  url: http://127.0.0.1:5000
 termsOfService: http://robokop.renci.org:7055/tos?service_long=ARAGORN&provider_long=RENCI
 title: ARAGORN
-version: 2.4.17
+version: 2.5.0
 tags:
 - name: translator
 - name: ARA

--- a/src/results_cache.py
+++ b/src/results_cache.py
@@ -1,0 +1,35 @@
+import os
+import redis
+import json
+
+CACHE_HOST = os.environ.get("CACHE_HOST", "localhost")
+CACHE_PORT = os.environ.get("CACHE_PORT", "6379")
+CACHE_DB = os.environ.get("CACHE_DB", "0")
+CACHE_PASSWORD = os.environ.get("CACHE_PASSWORD", "")
+
+class ResultsCache:
+    def __init__(self, redis_host=CACHE_HOST, redis_port=CACHE_PORT, redis_db=CACHE_DB, redis_password=CACHE_PASSWORD):
+        """Connect to cache."""
+        self.redis = redis.StrictRedis(
+            host=redis_host,
+            port=redis_port,
+            db=redis_db,
+            password=redis_password,
+            decode_responses=True)
+
+    def get_query_key(self, input_id, predicate, qualifiers, source_input, caller):
+        keydict = {'predicate': predicate, 'source_input': source_input, 'input_id': input_id, 'caller': caller}
+        keydict.update(qualifiers)
+        return json.dumps(keydict, sort_keys=True)
+
+    def get_result(self, input_id, predicate, qualifiers, source_input, caller):
+        key = self.get_query_key(input_id, predicate, qualifiers, source_input, caller)
+        result = self.redis.get(key)
+        if result is not None:
+            result = json.loads(result)
+        return result
+
+
+    def set_result(self, input_id, predicate, qualifiers, source_input, caller, final_answer):
+        key = self.get_query_key(input_id, predicate, qualifiers, source_input, caller)
+        self.redis.set(key, json.dumps(final_answer))

--- a/src/results_cache.py
+++ b/src/results_cache.py
@@ -35,3 +35,6 @@ class ResultsCache:
         key = self.get_query_key(input_id, predicate, qualifiers, source_input, caller, workflow)
 
         self.redis.set(key, gzip.compress(json.dumps(final_answer).encode()))
+    
+    def clear_cache(self):
+        self.redis.flushdb()

--- a/src/results_cache.py
+++ b/src/results_cache.py
@@ -18,20 +18,20 @@ class ResultsCache:
             password=redis_password,
         )
 
-    def get_query_key(self, input_id, predicate, qualifiers, source_input, caller):
-        keydict = {'predicate': predicate, 'source_input': source_input, 'input_id': input_id, 'caller': caller}
+    def get_query_key(self, input_id, predicate, qualifiers, source_input, caller, workflow):
+        keydict = {'predicate': predicate, 'source_input': source_input, 'input_id': input_id, 'caller': caller, 'workflow': workflow}
         keydict.update(qualifiers)
         return json.dumps(keydict, sort_keys=True)
 
-    def get_result(self, input_id, predicate, qualifiers, source_input, caller):
-        key = self.get_query_key(input_id, predicate, qualifiers, source_input, caller)
+    def get_result(self, input_id, predicate, qualifiers, source_input, caller, workflow):
+        key = self.get_query_key(input_id, predicate, qualifiers, source_input, caller, workflow)
         result = self.redis.get(key)
         if result is not None:
             result = json.loads(gzip.decompress(result))
         return result
 
 
-    def set_result(self, input_id, predicate, qualifiers, source_input, caller, final_answer):
-        key = self.get_query_key(input_id, predicate, qualifiers, source_input, caller)
-        
+    def set_result(self, input_id, predicate, qualifiers, source_input, caller, workflow, final_answer):
+        key = self.get_query_key(input_id, predicate, qualifiers, source_input, caller, workflow)
+
         self.redis.set(key, gzip.compress(json.dumps(final_answer).encode()))

--- a/src/service_aggregator.py
+++ b/src/service_aggregator.py
@@ -234,17 +234,10 @@ async def post_with_callback(host_url, query, guid, params={}):
         # these requests should be very quick, if the external service is responsive, they should send back a quick
         # response and then we watch the queue. We give a short 1 min timeout.
         async with httpx.AsyncClient(timeout=httpx.Timeout(timeout=60)) as client:
-            if params is None:
-                post_response = await client.post(
-                    host_url,
-                    json=query,
-                )
-            else:
-                post_response = await client.post(
-                    host_url,
-                    json=query,
-                    params=params,
-                )
+            post_response = await client.post(
+                host_url,
+                json=query,
+            )
         # check the response status.
         if post_response.status_code != 200:
             # queue isn't needed for failed service call

--- a/src/service_aggregator.py
+++ b/src/service_aggregator.py
@@ -152,7 +152,7 @@ async def entry(message, guid, coalesce_type, caller) -> (dict, int):
         # because we need these values to post to the cache at the end.
         input_id, predicate, qualifiers, source, source_input, target = get_infer_parameters(message)
         if not override_cache:
-            results = results_cache.get_result(input_id, predicate, qualifiers, source_input, caller)
+            results = results_cache.get_result(input_id, predicate, qualifiers, source_input, caller, workflow_def)
             if results is not None:
                 logger.info(f"{guid}: Returning results cache lookup")
                 return results, 200
@@ -174,7 +174,7 @@ async def entry(message, guid, coalesce_type, caller) -> (dict, int):
     final_answer["workflow"] = workflow_def
 
     if infer:
-        results_cache.set_result(input_id, predicate, qualifiers, source_input, caller, final_answer)
+        results_cache.set_result(input_id, predicate, qualifiers, source_input, caller, workflow_def, final_answer)
 
     # return the answer
     return final_answer, status_code

--- a/src/service_aggregator.py
+++ b/src/service_aggregator.py
@@ -774,7 +774,7 @@ def expand_query(input_message, params, guid):
     qg = deepcopy(input_message["message"]["query_graph"])
     for eid,edge in qg["edges"].items():
         del edge["knowledge_type"]
-    messages = [{"message": {"query_graph":qg}}]
+    messages = [{"message": {"query_graph":qg}, "parameters": params}]
     #If we don't have any AMIE expansions, this will just generate the direct query
     for rule_def in AMIE_EXPANSIONS.get(key,[]):
         query_template = Template(json.dumps(rule_def["template"]))
@@ -788,7 +788,7 @@ def expand_query(input_message, params, guid):
             del query["query_graph"]["nodes"][target]["ids"]
         else:
             del query["query_graph"]["nodes"][source]["ids"]
-        message = {"message": query}
+        message = {"message": query, "parameters": params}
         if "log_level" in input_message:
             message["log_level"] = input_message["log_level"]
         messages.append(message)


### PR DESCRIPTION
Adds a redis results cache to aragorn.   Probably acts badly if it can't reach such a cache...

Includes an override_cache and timeout_seconds parameters for controlling the cache's use.

Tested against aragorn and robokop.

You can see usage here: https://github.com/ranking-agent/robogallery/blob/master/Integration/ARAGORN_Cache.ipynb

Still needs to have the helm chart updated to include the redis and secrets etc.  I don't have a good sense of how much memory is needed, and I haven't explored the idea of compressing the trapi results in the redis.
