### PR TITLE
Aragorn cache

### DIFF
--- a/openapi-config.yaml
+++ b/openapi-config.yaml
@@ -11,7 +11,7 @@ servers:
 #  url: http://127.0.0.1:5000
 termsOfService: http://robokop.renci.org:7055/tos?service_long=ARAGORN&provider_long=RENCI
 title: ARAGORN
-version: 2.5.0
+version: 2.5.1
 tags:
 - name: translator
 - name: ARA

--- a/src/service_aggregator.py
+++ b/src/service_aggregator.py
@@ -121,10 +121,8 @@ async def entry(message, guid, coalesce_type, caller) -> (dict, int):
         del message["workflow"]
     else:
         if infer:
-            timeout_seconds = (message.get("parameters") or {}).get("timeout_seconds")
-            timeout_seconds = timeout_seconds if type(timeout_seconds) is int else 3 * 60
             workflow_def = [
-                {"id": "lookup", "parameters": {"timeout_seconds": timeout_seconds}},
+                {"id": "lookup"},
                 {"id": "overlay_connect_knodes"},
                 {"id": "score"},
                 {"id": "filter_message_top_n", "parameters": {"max_results": 500}},
@@ -626,6 +624,8 @@ async def aragorn_lookup(input_message, params, guid, infer, answer_qnode):
     if not infer:
         return await strider(input_message, params, guid)
     # Now it's an infer query.
+    timeout_seconds = (input_message.get("parameters") or {}).get("timeout_seconds")
+    params["timeout_seconds"] = timeout_seconds if type(timeout_seconds) is int else 3 * 60
     messages = expand_query(input_message, params, guid)
     lookup_query_graph = messages[0]["message"]["query_graph"]
     nrules_per_batch = int(os.environ.get("MULTISTRIDER_BATCH_SIZE", 101))


### PR DESCRIPTION
Adding timeout_seconds to the workflow_def is actually being saved in the cache, so anything preseeded with a longer timeout won't be hit by another query that has no timeout specified. This moved the timeout_seconds down in the workflow so it's added only when it's needed after the cache hit.