### PR TITLE
Add caching for lookups

### DIFF
--- a/openapi-config.yaml
+++ b/openapi-config.yaml
@@ -11,7 +11,7 @@ servers:
 #  url: http://127.0.0.1:5000
 termsOfService: http://robokop.renci.org:7055/tos?service_long=ARAGORN&provider_long=RENCI
 title: ARAGORN
-version: 2.5.2
+version: 2.6.0
 tags:
 - name: translator
 - name: ARA

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pytest-asyncio==0.15.1
 pytest-dotenv==0.5.2
 pyyaml==6.0
 reasoner-pydantic==4.1.1
-redis==4.3.4
+redis~=3.5.3
 requests==2.28.1
 uvicorn==0.17.6
 uvloop==0.17.0
@@ -20,4 +20,4 @@ opentelemetry-sdk==1.16.0
 opentelemetry-instrumentation-fastapi==0.37b0
 opentelemetry-exporter-jaeger==1.16.0
 opentelemetry-instrumentation-httpx==0.37b0
-fakeredis==2.10.2
+fakeredis<=2.10.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ opentelemetry-sdk==1.16.0
 opentelemetry-instrumentation-fastapi==0.37b0
 opentelemetry-exporter-jaeger==1.16.0
 opentelemetry-instrumentation-httpx==0.37b0
+fakeredis<=2.10.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pytest-asyncio==0.15.1
 pytest-dotenv==0.5.2
 pyyaml==6.0
 reasoner-pydantic==4.1.1
-redis~=3.5.3
+redis==4.3.4
 requests==2.28.1
 uvicorn==0.17.6
 uvloop==0.17.0
@@ -20,4 +20,4 @@ opentelemetry-sdk==1.16.0
 opentelemetry-instrumentation-fastapi==0.37b0
 opentelemetry-exporter-jaeger==1.16.0
 opentelemetry-instrumentation-httpx==0.37b0
-fakeredis<=2.10.2
+fakeredis==2.10.2

--- a/src/aragorn_app.py
+++ b/src/aragorn_app.py
@@ -188,12 +188,23 @@ class ClearCacheRequest(BaseModel):
     pswd: str
 
 
-@ARAGORN_APP.post("/clear_cache", status_code=200, include_in_schema=False)
+@ARAGORN_APP.post("/clear_creative_cache", status_code=200, include_in_schema=False)
 def clear_redis_cache(request: ClearCacheRequest) -> dict:
     """Clear the redis cache."""
     if request.pswd == cache_password:
         cache = ResultsCache()
-        cache.clear_cache()
+        cache.clear_creative_cache()
+        return {"status": "success"}
+    else:
+        raise HTTPException(status_code=401, detail="Invalid Password")
+
+
+@ARAGORN_APP.post("/clear_lookup_cache", status_code=200, include_in_schema=False)
+def clear_redis_cache(request: ClearCacheRequest) -> dict:
+    """Clear the redis cache."""
+    if request.pswd == cache_password:
+        cache = ResultsCache()
+        cache.clear_lookup_cache()
         return {"status": "success"}
     else:
         raise HTTPException(status_code=401, detail="Invalid Password")

--- a/src/results_cache.py
+++ b/src/results_cache.py
@@ -41,7 +41,7 @@ class ResultsCache:
         return json.dumps(keydict, sort_keys=True)
 
     def get_lookup_result(self, workflow, query_graph):
-        key = self.get_query_key(workflow, query_graph)
+        key = self.get_lookup_query_key(workflow, query_graph)
         result = self.redis.get(key)
         if result is not None:
             result = json.loads(gzip.decompress(result))
@@ -49,7 +49,7 @@ class ResultsCache:
 
 
     def set_lookup_result(self, workflow, query_graph, final_answer):
-        key = self.get_query_key(workflow, query_graph)
+        key = self.get_lookup_query_key(workflow, query_graph)
 
         self.redis.set(key, gzip.compress(json.dumps(final_answer).encode()))
 

--- a/src/results_cache.py
+++ b/src/results_cache.py
@@ -35,6 +35,24 @@ class ResultsCache:
         key = self.get_query_key(input_id, predicate, qualifiers, source_input, caller, workflow)
 
         self.redis.set(key, gzip.compress(json.dumps(final_answer).encode()))
+
+    def get_lookup_query_key(self, workflow, query_graph):
+        keydict = {'workflow': workflow, 'query_graph': query_graph}
+        return json.dumps(keydict, sort_keys=True)
+
+    def get_lookup_result(self, workflow, query_graph):
+        key = self.get_query_key(workflow, query_graph)
+        result = self.redis.get(key)
+        if result is not None:
+            result = json.loads(gzip.decompress(result))
+        return result
+
+
+    def set_lookup_result(self, workflow, query_graph, final_answer):
+        key = self.get_query_key(workflow, query_graph)
+
+        self.redis.set(key, gzip.compress(json.dumps(final_answer).encode()))
+
     
     def clear_cache(self):
         self.redis.flushdb()

--- a/src/results_cache.py
+++ b/src/results_cache.py
@@ -7,6 +7,7 @@ CACHE_HOST = os.environ.get("CACHE_HOST", "localhost")
 CACHE_PORT = os.environ.get("CACHE_PORT", "6379")
 CREATIVE_CACHE_DB = os.environ.get("CREATIVE_CACHE_DB", "0")
 LOOKUP_CACHE_DB = os.environ.get("LOOKUP_CACHE_DB", "1")
+CACHE_PASSWORD = os.environ.get("CACHE_PASSWORD", "")
 
 class ResultsCache:
     def __init__(

--- a/src/service_aggregator.py
+++ b/src/service_aggregator.py
@@ -187,7 +187,7 @@ async def entry(message, guid, coalesce_type, caller) -> (dict, int):
         if not override_cache:
             try:
                 query_graph = message["query_graph"]
-            except:
+            except KeyError:
                 return f"No query graph", 422
             results = results_cache.get_lookup_result(workflow_def, query_graph)
             if results is not None:

--- a/src/service_aggregator.py
+++ b/src/service_aggregator.py
@@ -165,6 +165,10 @@ async def entry(message, guid, coalesce_type, caller) -> (dict, int):
     # We told the world what we can do!
     # Workflow will be a list of the functions, and the parameters if there are any
 
+    try:
+        query_graph = message["message"]["query_graph"]
+    except KeyError:
+        return f"No query graph", 422
     results_cache = ResultsCache()
     override_cache = (message.get("parameters") or {}).get("override_cache")
     override_cache = override_cache if type(override_cache) is bool else False
@@ -185,10 +189,6 @@ async def entry(message, guid, coalesce_type, caller) -> (dict, int):
                 logger.info(f"{guid}: Results cache miss")
     else:
         if not override_cache:
-            try:
-                query_graph = message["message"]["query_graph"]
-            except KeyError:
-                return f"No query graph", 422
             results = results_cache.get_lookup_result(workflow_def, query_graph)
             if results is not None:
                 logger.info(f"{guid}: Returning results cache lookup")
@@ -210,8 +210,7 @@ async def entry(message, guid, coalesce_type, caller) -> (dict, int):
 
     if infer:
         results_cache.set_result(input_id, predicate, qualifiers, source_input, caller, workflow_def, final_answer)
-    else: 
-        query_graph = message["query_graph"]
+    else:
         results_cache.set_lookup_result(workflow_def, query_graph, final_answer)
 
     # return the answer

--- a/src/service_aggregator.py
+++ b/src/service_aggregator.py
@@ -188,7 +188,7 @@ async def entry(message, guid, coalesce_type, caller) -> (dict, int):
             try:
                 query_graph = message["query_graph"]
             except KeyError:
-                return f"No query graph", 422
+                return f"No query graph", 400
             results = results_cache.get_lookup_result(workflow_def, query_graph)
             if results is not None:
                 logger.info(f"{guid}: Returning results cache lookup")

--- a/src/service_aggregator.py
+++ b/src/service_aggregator.py
@@ -186,9 +186,9 @@ async def entry(message, guid, coalesce_type, caller) -> (dict, int):
     else:
         if not override_cache:
             try:
-                query_graph = message["query_graph"]
+                query_graph = message["message"]["query_graph"]
             except KeyError:
-                return f"No query graph", 400
+                return f"No query graph", 422
             results = results_cache.get_lookup_result(workflow_def, query_graph)
             if results is not None:
                 logger.info(f"{guid}: Returning results cache lookup")

--- a/tests/helpers/redisMock.py
+++ b/tests/helpers/redisMock.py
@@ -2,9 +2,9 @@ import fakeredis
 import gzip
 import json
 
-async def redisMock(connection_pool=None):
+def redisMock(host=None, port=None, db=None, password=None):
     # Here's where I got documentation for how to do async fakeredis:
     # https://github.com/cunla/fakeredis-py/issues/66#issuecomment-1316045893
-    redis = await fakeredis.FakeStrictRedis
+    redis = fakeredis.FakeStrictRedis()
     # set up mock function
     return redis

--- a/tests/helpers/redisMock.py
+++ b/tests/helpers/redisMock.py
@@ -1,0 +1,10 @@
+import fakeredis.aioredis as fakeredis
+import gzip
+import json
+
+async def redisMock(connection_pool=None):
+    # Here's where I got documentation for how to do async fakeredis:
+    # https://github.com/cunla/fakeredis-py/issues/66#issuecomment-1316045893
+    redis = await fakeredis.FakeRedis()
+    # set up mock function
+    return redis

--- a/tests/helpers/redisMock.py
+++ b/tests/helpers/redisMock.py
@@ -1,10 +1,10 @@
-import fakeredis.aioredis as fakeredis
+import fakeredis
 import gzip
 import json
 
 async def redisMock(connection_pool=None):
     # Here's where I got documentation for how to do async fakeredis:
     # https://github.com/cunla/fakeredis-py/issues/66#issuecomment-1316045893
-    redis = await fakeredis.FakeRedis()
+    redis = await fakeredis.FakeStrictRedis
     # set up mock function
     return redis

--- a/tests/test_aragorn.py
+++ b/tests/test_aragorn.py
@@ -1,6 +1,6 @@
 import pytest
 from fastapi.testclient import TestClient
-import redis.asyncio
+import redis
 from src.server import APP
 import os
 import json
@@ -49,7 +49,7 @@ def xtest_async(mock_callback):
 
 
 def test_aragorn_wf(monkeypatch):
-    monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
+    monkeypatch.setattr(redis, "Redis", redisMock)
     init_db()
     workflow_A1("aragorn")
 
@@ -300,7 +300,7 @@ def x_test_standup_2():
     assert found
 
 def test_null_results(monkeypatch):
-    monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
+    monkeypatch.setattr(redis, "Redis", redisMock)
     init_db()
     #make sure that aragorn can handle cases where results is null (as opposed to missing)
     query= {

--- a/tests/test_aragorn.py
+++ b/tests/test_aragorn.py
@@ -49,7 +49,7 @@ def xtest_async(mock_callback):
 
 
 def test_aragorn_wf(monkeypatch):
-    monkeypatch.setattr(redis, "Redis", redisMock)
+    monkeypatch.setattr(redis, "StrictRedis", redisMock)
     init_db()
     workflow_A1("aragorn")
 
@@ -300,7 +300,7 @@ def x_test_standup_2():
     assert found
 
 def test_null_results(monkeypatch):
-    monkeypatch.setattr(redis, "Redis", redisMock)
+    monkeypatch.setattr(redis, "StrictRedis", redisMock)
     init_db()
     #make sure that aragorn can handle cases where results is null (as opposed to missing)
     query= {

--- a/tests/test_aragorn.py
+++ b/tests/test_aragorn.py
@@ -1,5 +1,6 @@
 import pytest
 from fastapi.testclient import TestClient
+import redis.asyncio
 from src.server import APP
 import os
 import json
@@ -7,6 +8,7 @@ from datetime import datetime as dt, timedelta
 from time import sleep
 from unittest.mock import patch
 from src.process_db import init_db
+from tests.helpers.redisMock import redisMock
 
 client = TestClient(APP)
 
@@ -46,7 +48,8 @@ def xtest_async(mock_callback):
     assert mock_callback.called
 
 
-def test_aragorn_wf():
+def test_aragorn_wf(monkeypatch):
+    monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
     init_db()
     workflow_A1("aragorn")
 
@@ -296,7 +299,8 @@ def x_test_standup_2():
 
     assert found
 
-def test_null_results():
+def test_null_results(monkeypatch):
+    monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
     init_db()
     #make sure that aragorn can handle cases where results is null (as opposed to missing)
     query= {

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,6 +1,6 @@
 import pytest
 from fastapi.testclient import TestClient
-import redis.asyncio
+import redis
 from src.server import APP as APP
 from src import operations
 import os
@@ -14,7 +14,7 @@ client = TestClient(APP)
 jsondir = 'InputJson_1.2'
 
 def test_bad_ops(monkeypatch):
-    monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
+    monkeypatch.setattr(redis, "Redis", redisMock)
     # get the location of the test file
     dir_path: str = os.path.dirname(os.path.realpath(__file__))
     test_filename = os.path.join(dir_path, jsondir, 'workflow_422.json')
@@ -30,7 +30,7 @@ def test_bad_ops(monkeypatch):
 
 def test_lookup_only(monkeypatch):
     """This has a workflow with a single op (lookup).  So the result should not have scores"""
-    monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
+    monkeypatch.setattr(redis, "Redis", redisMock)
     init_db()
     dir_path: str = os.path.dirname(os.path.realpath(__file__))
     test_filename = os.path.join(dir_path, jsondir, 'workflow_200.json')

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -14,7 +14,7 @@ client = TestClient(APP)
 jsondir = 'InputJson_1.2'
 
 def test_bad_ops(monkeypatch):
-    monkeypatch.setattr(redis, "Redis", redisMock)
+    monkeypatch.setattr(redis, "StrictRedis", redisMock)
     # get the location of the test file
     dir_path: str = os.path.dirname(os.path.realpath(__file__))
     test_filename = os.path.join(dir_path, jsondir, 'workflow_422.json')
@@ -30,7 +30,7 @@ def test_bad_ops(monkeypatch):
 
 def test_lookup_only(monkeypatch):
     """This has a workflow with a single op (lookup).  So the result should not have scores"""
-    monkeypatch.setattr(redis, "Redis", redisMock)
+    monkeypatch.setattr(redis, "StrictRedis", redisMock)
     init_db()
     dir_path: str = os.path.dirname(os.path.realpath(__file__))
     test_filename = os.path.join(dir_path, jsondir, 'workflow_200.json')

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,5 +1,6 @@
 import pytest
 from fastapi.testclient import TestClient
+import redis.asyncio
 from src.server import APP as APP
 from src import operations
 import os
@@ -7,11 +8,13 @@ import json
 from unittest.mock import patch
 from random import shuffle
 from src.process_db import init_db
+from tests.helpers.redisMock import redisMock
 
 client = TestClient(APP)
 jsondir = 'InputJson_1.2'
 
-def test_bad_ops():
+def test_bad_ops(monkeypatch):
+    monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
     # get the location of the test file
     dir_path: str = os.path.dirname(os.path.realpath(__file__))
     test_filename = os.path.join(dir_path, jsondir, 'workflow_422.json')
@@ -25,8 +28,9 @@ def test_bad_ops():
     # was the request successful
     assert(response.status_code == 422)
 
-def test_lookup_only():
+def test_lookup_only(monkeypatch):
     """This has a workflow with a single op (lookup).  So the result should not have scores"""
+    monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
     init_db()
     dir_path: str = os.path.dirname(os.path.realpath(__file__))
     test_filename = os.path.join(dir_path, jsondir, 'workflow_200.json')


### PR DESCRIPTION
Adds caching for lookups. Preserves keys used by inferred queries for inferred queries and uses the whole query graph as the key for lookups. This is brittle and we may want to explore a more robust key in the future. 

Tests fail because the redis cache is not instantiated during testing and therefore errors out. 