### PR TITLE
Only cache lookup

### DIFF
--- a/openapi-config.yaml
+++ b/openapi-config.yaml
@@ -11,7 +11,7 @@ servers:
 #  url: http://127.0.0.1:5000
 termsOfService: http://robokop.renci.org:7055/tos?service_long=ARAGORN&provider_long=RENCI
 title: ARAGORN
-version: 2.6.0
+version: 2.6.1
 tags:
 - name: translator
 - name: ARA

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ pytest==7.1.2
 pytest-asyncio==0.15.1
 pytest-dotenv==0.5.2
 pyyaml==6.0
-reasoner-pydantic==4.1.1
+reasoner-pydantic==4.1.6
 redis~=3.5.3
 requests==2.28.1
 uvicorn==0.17.6

--- a/src/service_aggregator.py
+++ b/src/service_aggregator.py
@@ -210,7 +210,7 @@ async def entry(message, guid, coalesce_type, caller) -> (dict, int):
 
     if infer:
         results_cache.set_result(input_id, predicate, qualifiers, source_input, caller, workflow_def, final_answer)
-    else:
+    elif {"id": "lookup"} in workflow_def or override_cache:
         results_cache.set_lookup_result(workflow_def, query_graph, final_answer)
 
     # return the answer

--- a/tests/test_query_exam.py
+++ b/tests/test_query_exam.py
@@ -34,6 +34,10 @@ def test_merge_answer_creative_only():
     result1 = create_result({"input":"MONDO:1234", "output":answer, "node2": "curie:3"}, {"g":"KEDGE:1", "f":"KEDGE:2"}).to_dict()
     result2 = create_result({"input":"MONDO:1234", "output":answer, "nodeX": "curie:8"}, {"q":"KEDGE:4", "z":"KEDGE:8"}).to_dict()
     results = [result1, result2]
+    result_message["message"]["knowledge_graph"]["edges"]["KEDGE:1"] = create_pretend_knowledge_edge("MONDO:1234", "MONDO:4567", "biolink:related_to", "infores:kp1")
+    result_message["message"]["knowledge_graph"]["edges"]["KEDGE:2"] = create_pretend_knowledge_edge("MONDO:4567", answer, "biolink:treats", "infores:kp1")
+    result_message["message"]["knowledge_graph"]["edges"]["KEDGE:1"] = create_pretend_knowledge_edge("MONDO:1234", "MONDO:7890", "biolink:related_to", "infores:kp1")
+    result_message["message"]["knowledge_graph"]["edges"]["KEDGE:1"] = create_pretend_knowledge_edge("MONDO:7890", answer, "biolink:treats", "infores:kp1")
 
     #In reality the results will be in the message and we want to be sure that they get cleared out.
     result_message["message"]["results"] = results

--- a/tests/test_query_exam.py
+++ b/tests/test_query_exam.py
@@ -34,10 +34,11 @@ def test_merge_answer_creative_only():
     result1 = create_result({"input":"MONDO:1234", "output":answer, "node2": "curie:3"}, {"g":"KEDGE:1", "f":"KEDGE:2"}).to_dict()
     result2 = create_result({"input":"MONDO:1234", "output":answer, "nodeX": "curie:8"}, {"q":"KEDGE:4", "z":"KEDGE:8"}).to_dict()
     results = [result1, result2]
-    result_message["message"]["knowledge_graph"]["edges"]["KEDGE:1"] = create_pretend_knowledge_edge("MONDO:1234", "MONDO:4567", "biolink:related_to", "infores:kp1")
-    result_message["message"]["knowledge_graph"]["edges"]["KEDGE:2"] = create_pretend_knowledge_edge("MONDO:4567", answer, "biolink:treats", "infores:kp1")
-    result_message["message"]["knowledge_graph"]["edges"]["KEDGE:1"] = create_pretend_knowledge_edge("MONDO:1234", "MONDO:7890", "biolink:related_to", "infores:kp1")
-    result_message["message"]["knowledge_graph"]["edges"]["KEDGE:1"] = create_pretend_knowledge_edge("MONDO:7890", answer, "biolink:treats", "infores:kp1")
+    #create kedges neccessary for parsing
+    result_message["message"]["knowledge_graph"]["edges"]["KEDGE:1"] = create_pretend_knowledge_edge("MONDO:1234", "curie:3", "biolink:related_to", "infores:kp1")
+    result_message["message"]["knowledge_graph"]["edges"]["KEDGE:2"] = create_pretend_knowledge_edge("curie:3", answer, "biolink:treats", "infores:kp1")
+    result_message["message"]["knowledge_graph"]["edges"]["KEDGE:4"] = create_pretend_knowledge_edge("MONDO:1234", "curie:8", "biolink:related_to", "infores:kp1")
+    result_message["message"]["knowledge_graph"]["edges"]["KEDGE:8"] = create_pretend_knowledge_edge("curie:8", answer, "biolink:treats", "infores:kp1")
 
     #In reality the results will be in the message and we want to be sure that they get cleared out.
     result_message["message"]["results"] = results
@@ -96,6 +97,11 @@ def test_merge_answer_creative_and_lookup():
     qnode_ids = ["input", "output"]
     result1 = create_result({"input":"MONDO:1234", "output":answer, "node2": "curie:3"}, {"g":"KEDGE:1", "f":"KEDGE:2"}).to_dict()
     result2 = create_result({"input":"MONDO:1234", "output":answer, "nodeX": "curie:8"}, {"q":"KEDGE:4", "z":"KEDGE:8"}).to_dict()
+    #create kedges neccessary for parsing
+    result_message["message"]["knowledge_graph"]["edges"]["KEDGE:1"] = create_pretend_knowledge_edge("MONDO:1234", "curie:3", "biolink:related_to", "infores:kp1")
+    result_message["message"]["knowledge_graph"]["edges"]["KEDGE:2"] = create_pretend_knowledge_edge("curie:3", answer, "biolink:treats", "infores:kp1")
+    result_message["message"]["knowledge_graph"]["edges"]["KEDGE:4"] = create_pretend_knowledge_edge("MONDO:1234", "curie:8", "biolink:related_to", "infores:kp1")
+    result_message["message"]["knowledge_graph"]["edges"]["KEDGE:8"] = create_pretend_knowledge_edge("curie:8", answer, "biolink:treats", "infores:kp1")
     results = [result1, result2]
     lookup = [create_result({"input":"MONDO:1234", "output":answer}, {"e":"lookup:1"}).dict(exclude_none=True)]
     for n, ke_id in enumerate(["lookup:1"]):


### PR DESCRIPTION
Only caches non-inferred queries when `lookup` is one of the operations, unless override_cache is an included parameter. Also caches default workflow, since lookup is an implicit operation in that case.