### PR TITLE
Add Recursive Filtering

### DIFF
--- a/openapi-config.yaml
+++ b/openapi-config.yaml
@@ -11,7 +11,7 @@ servers:
 #  url: http://127.0.0.1:5000
 termsOfService: http://robokop.renci.org:7055/tos?service_long=ARAGORN&provider_long=RENCI
 title: ARAGORN
-version: 2.9.2
+version: 2.9.3
 tags:
 - name: translator
 - name: ARA

--- a/src/operations.py
+++ b/src/operations.py
@@ -78,6 +78,7 @@ async def filter_kgraph_orphans(message,params,guid):
         edges = set()
         auxgraphs = set()
         temp_auxgraphs = set()
+        temp_edges = set()
         # 1. Result node bindings
         for result in results:
             for qnode,knodes in result.get('node_bindings',{}).items():
@@ -86,7 +87,7 @@ async def filter_kgraph_orphans(message,params,guid):
         for result in results:
             for analysis in result.get('analyses',[]):
                 for qedge, kedges in analysis.get('edge_bindings', {}).items():
-                    edges.update([k['id'] for k in kedges])
+                    temp_edges.update([k['id'] for k in kedges])
                 for qpath, path_graphs in analysis.get('path_bindings', {}).items():
                     temp_auxgraphs.update(a["id"] for a in path_graphs)
         # 3. Result.Analysis support graphs
@@ -95,7 +96,8 @@ async def filter_kgraph_orphans(message,params,guid):
                 for auxgraph in analysis.get('support_graphs',[]):
                     temp_auxgraphs.add(auxgraph)
         # 4. Recursively add support graphs from edges and edges from support_graphs
-        for edge in edges:
+        for edge in temp_edges:
+            edges.add(edge)
             edges, auxgraphs, nodes = recursive_filter_edge_support_graphs(edge, edges, auxgraphs, message, nodes)
         # 5. Recursively add edges from support_graphs and support graphs from edges
         for auxgraph in temp_auxgraphs:


### PR DESCRIPTION
Adds recursive methods for filtering edges and auxiliary graphs. Will break if there is any self referential edge/auxiliary graph pairs (edge `E` has a support graph as auxiliary graph`A`. Auxiliary graph `A` contains edge `E`), but that would be a whole other issue entirely.