### PR TITLE
Fix OTEL ImportError: migrate from deprecated Jaeger exporter to OTLP

### DIFF
--- a/openapi-config.yaml
+++ b/openapi-config.yaml
@@ -11,7 +11,7 @@ servers:
 #  url: http://127.0.0.1:5000
 termsOfService: http://robokop.renci.org:7055/tos?service_long=ARAGORN&provider_long=RENCI
 title: ARAGORN
-version: 2.9.6
+version: 2.9.7
 tags:
 - name: translator
 - name: ARA

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ uvicorn==0.17.6
 uvloop==0.19.0
 opentelemetry-sdk==1.16.0
 opentelemetry-instrumentation-fastapi==0.37b0
-opentelemetry-exporter-jaeger==1.16.0
+opentelemetry-exporter-otlp-proto-grpc==1.16.0
 opentelemetry-instrumentation-httpx==0.37b0
 fakeredis<=2.10.2
 networkx==3.2.1

--- a/src/otel_config.py
+++ b/src/otel_config.py
@@ -4,11 +4,11 @@ import logging, warnings, os
 def configure_otel(service_name, APP):
     # open telemetry
     if os.environ.get('JAEGER_ENABLED') == "True":
-        logging.info("starting up jaeger telemetry")
+        logging.info("starting up otel telemetry")
 
         from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
         from opentelemetry import trace
-        from opentelemetry.exporter.jaeger.thrift import JaegerExporter
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
         from opentelemetry.sdk.resources import SERVICE_NAME as telemetery_service_name_key, Resource
         from opentelemetry.sdk.trace import TracerProvider
         from opentelemetry.sdk.trace.export import BatchSpanProcessor
@@ -19,20 +19,27 @@ def configure_otel(service_name, APP):
         # these supresses such warnings.
         logging.captureWarnings(capture=True)
         warnings.filterwarnings("ignore",category=ResourceWarning)
-        jaeger_host = os.environ.get('JAEGER_HOST', 'jaeger-otel-agent')
-        jaeger_port = int(os.environ.get('JAEGER_PORT', '6831'))
-        trace.set_tracer_provider(
-            TracerProvider(
-                resource=Resource.create({telemetery_service_name_key: service_name})
-            )
+
+        provider = TracerProvider(
+            resource=Resource.create({telemetery_service_name_key: service_name})
         )
-        jaeger_exporter = JaegerExporter(
-            agent_host_name=jaeger_host,
-            agent_port=jaeger_port,
+
+        # Export via OTLP. The Jaeger exporter has been deprecated and removed from
+        # OpenTelemetry (Jaeger ingests OTLP natively now). Prefer the endpoint provided
+        # by the environment -- e.g. injected by the OpenTelemetry Operator
+        # auto-instrumentation -- otherwise fall back to JAEGER_HOST/JAEGER_PORT for
+        # standalone runs, defaulting to the standard OTLP gRPC port.
+        if os.environ.get('OTEL_EXPORTER_OTLP_ENDPOINT'):
+            otlp_exporter = OTLPSpanExporter()
+        else:
+            otlp_host = os.environ.get('JAEGER_HOST', 'jaeger-otel-agent')
+            otlp_port = os.environ.get('JAEGER_PORT', '4317')
+            otlp_exporter = OTLPSpanExporter(endpoint=f"{otlp_host}:{otlp_port}", insecure=True)
+
+        provider.add_span_processor(
+            BatchSpanProcessor(otlp_exporter)
         )
-        trace.get_tracer_provider().add_span_processor(
-            BatchSpanProcessor(jaeger_exporter)
-        )
-        tracer = trace.get_tracer(__name__)
-        FastAPIInstrumentor.instrument_app(APP, tracer_provider=trace, excluded_urls="docs,openapi.json")
-        HTTPXClientInstrumentor().instrument()
+        trace.set_tracer_provider(provider)
+
+        FastAPIInstrumentor.instrument_app(APP, tracer_provider=provider, excluded_urls="docs,openapi.json")
+        HTTPXClientInstrumentor().instrument(tracer_provider=provider)


### PR DESCRIPTION
The Jaeger exporter was deprecated and removed from OpenTelemetry, and the newer opentelemetry-sdk injected by the OTEL Operator auto-instrumentation no longer defines OTEL_EXPORTER_JAEGER_AGENT_HOST. This caused an ImportError at startup when opentelemetry-exporter-jaeger tried to import that constant from opentelemetry.sdk.environment_variables.

Switch configure_otel() to the OTLP gRPC span exporter (Jaeger ingests OTLP natively now). It prefers the operator-provided OTEL_EXPORTER_OTLP_ENDPOINT and falls back to JAEGER_HOST/JAEGER_PORT (default OTLP gRPC port 4317) for standalone runs. Also fix a latent bug where the trace module was passed as the tracer_provider to FastAPIInstrumentor instead of the actual provider.

Replace opentelemetry-exporter-jaeger with opentelemetry-exporter-otlp-proto-grpc in requirements.txt.