### PR TITLE
Bump OpenTelemetry stack to a consistent 1.42.1 to fix OTLP common skew

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,9 +16,10 @@ redis~=3.5.3
 requests==2.28.1
 uvicorn==0.17.6
 uvloop==0.19.0
-opentelemetry-sdk==1.16.0
-opentelemetry-instrumentation-fastapi==0.37b0
-opentelemetry-exporter-otlp-proto-grpc==1.16.0
-opentelemetry-instrumentation-httpx==0.37b0
+opentelemetry-sdk==1.42.1
+opentelemetry-instrumentation-fastapi==0.63b1
+opentelemetry-exporter-otlp-proto-grpc==1.42.1
+opentelemetry-exporter-otlp-proto-common==1.42.1
+opentelemetry-instrumentation-httpx==0.63b1
 fakeredis<=2.10.2
 networkx==3.2.1


### PR DESCRIPTION
After switching to the OTLP gRPC exporter, startup failed with:
  ImportError: cannot import name '_create_exp_backoff_generator' from
  'opentelemetry.exporter.otlp.proto.common._internal'

The OTLP exporter is split across opentelemetry-exporter-otlp-proto-grpc and opentelemetry-exporter-otlp-proto-common, and those packages share a private internal API that changes between releases. Pinning the exporter to the old 1.16.0 line (which predates the common package entirely and still used the external `backoff` library) clashes with the much newer opentelemetry-exporter-otlp-proto-common that the OpenTelemetry Operator auto-instrumentation injects on PYTHONPATH: the helper _create_exp_backoff_generator lived in common._internal through 1.34 and was removed around 1.35, so an old grpc exporter importing it against a >=1.35 common fails.

Move the whole OTLP/SDK/instrumentation stack to one consistent recent release (core 1.42.1 / instrumentation 0.63b1) and pin
opentelemetry-exporter-otlp-proto-common explicitly so the grpc exporter and its common package can never diverge. Verified the set resolves and configure_otel runs end-to-end against the project's pinned fastapi 0.83.0 / starlette 0.19.1.